### PR TITLE
Leaflet - Add tile load event to remove warning, so errors previous e…

### DIFF
--- a/OSMapsAPI/Leaflet/map.js
+++ b/OSMapsAPI/Leaflet/map.js
@@ -81,6 +81,12 @@ function setupLayer() {
         message.textContent = 'Could not connect to the API. Ensure you are entering a project API key for a project that contains the OS Maps API';
         instructions.classList.remove("hidden");
     });
+    // Remove warning and hide instructions on tile load. This is so tileerror message does not persist when returning to a valid zoom level
+    layer.on('tileloadstart', function(event) {
+        message.classList.remove("warning");
+        message.textContent = 'To view the map, please enter a valid API key.';
+        instructions.classList.add("hidden");
+    });
     mapOptions.layers = layer;
     // Create the map object and connect it to the 'map' element in the html
     map = L.map('map', mapOptions);

--- a/OSMapsAPI/OpenLayers/map.js
+++ b/OSMapsAPI/OpenLayers/map.js
@@ -62,7 +62,7 @@ function setupLayer() {
                 projection: options.projection,
                 center: [-121099, 7161610],
                 resolutions: options.tileGrid.getResolutions(),
-                zoom: 10
+                zoom: 8
             };
             
             // If we are using a layer in British National Grid (EPSG:27700), then tranform the center point from


### PR DESCRIPTION
Leaflet - Add tile load event to remove warning, so previous errors don't persist when changing to a valid zoom level.
OpenLayers - Change default zoom level, so that 3857 layers start on an open data layer, and not premium